### PR TITLE
make steal-react-jsx compatible with steal 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 This stealJS extension let you steal `*.jsx` files.
 `Steal-react-jsx` use [Babel's react present](http://babeljs.io/docs/plugins/preset-react/) to transform `*.jsx` files.
 
+## StealJS Support
+
+* Use `steal-react-jsx` version `0.0.4` with `steal` >= `1.0.0`
+* Use `steal-react-jsx` version `0.0.3` with `steal` < `1.0.0` 
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This stealJS extension let you steal `*.jsx` files.
 
 ## StealJS Support
 
-* Use `steal-react-jsx` version `0.0.4` with `steal` >= `1.0.0`
+* Use `steal-react-jsx` version `0.1.0` with `steal` >= `1.0.0`
 * Use `steal-react-jsx` version `0.0.3` with `steal` < `1.0.0` 
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steal-react-jsx",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A StealJS plugin that enables importing reacts `*.jsx` files.",
   "main": "steal-react-jsx.js",
   "repository": {
@@ -14,18 +14,14 @@
   "author": "Bitovi",
   "license": "MIT",
   "system": {
-    "transpiler": "babel",
-    "babelOptions": {
-      "blacklist": []
-    },
     "ext": {
       "jsx": "steal-react-jsx"
     }
   },
   "devDependencies": {
-    "react": "^15.0.1",
-    "react-dom": "^15.0.1",
-    "steal": "^0.16.0",
+    "react": "^15.2.0",
+    "react-dom": "^15.2.0",
+    "steal": "^1.0.0-beta",
     "funcunit": "^3.0.0",
     "jshint": "^2.8.0",
     "steal-qunit": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steal-react-jsx",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "A StealJS plugin that enables importing reacts `*.jsx` files.",
   "main": "steal-react-jsx.js",
   "repository": {


### PR DESCRIPTION
babel is now default transpiler and with babel 6 blacklist option is gone

close https://github.com/stealjs/steal/issues/772

merge and release only if steal 1.0 is released
