### PR TITLE
Make node engines >= 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "testee": "^0.2.2"
   },
   "engines": {
-    "node": "4.x - 5.x.x"
+    "node": ">= 4.x"
   }
 }


### PR DESCRIPTION
In an environment using node >= 6.x, yarn complains when installing this package because the upper bound of the `engines` field is node 5.x.

This PR opens that up to be node >= 4.x to make yarn happy.